### PR TITLE
add TxOutput field to Transaction model as single TransactionOutput

### DIFF
--- a/models/transaction.go
+++ b/models/transaction.go
@@ -40,7 +40,8 @@ type Transaction struct {
 	FromAddress   *Address             `json:"from_address" pg:"fk:from_address_id"`              //Relation has one to Address
 	GasCoin       *Coin                `json:"gas_coin"     pg:"fk:gas_coin_id"`                  //Relation has one to Coin
 	Validators    []*Validator         `json:"validators"   pg:"many2many:transaction_validator"` //Relation has many to Validators
-	TxOutput      []*TransactionOutput `json:"tx_output"`                                         //Relation has one to TransactionOutputs
+	TxOutputs     []*TransactionOutput `json:"tx_outputs"`
+	TxOutput      *TransactionOutput   `json:"tx_output"`
 }
 
 type SendTxData struct {


### PR DESCRIPTION
TxOutputs - массив выходов
TxOutput - конкретный выход
Для чего нужно: при запросе транзакций, мультисенд транзакция идет как не одной транзакций, а отдельными (send) транзакциями. Поэтому чтобы я мог контролировать атрибуты из таблицы выходов, мне нужно поле в модели Transaction для конкретного выхода (а не массива)