### PR TITLE
Fix block validador model

### DIFF
--- a/models/block.go
+++ b/models/block.go
@@ -16,9 +16,14 @@ type Block struct {
 	BlockReward         string                `json:"block_reward" sql:"type:numeric(70)"`
 	Hash                string                `json:"hash"`
 	Proposer            *Validator            `json:"proposer" pg:"fk:proposer_validator_id"`    //relation has one to Validators
-	Validators          []*Validator          `json:"validators" pg:"many2many:block_validator"` //relation has many to Validators
+	BlockValidators     []BlockValidator      `json:"block_validators"`                          //relation has many to BlockValidators
 	Transactions        []*Transaction        `json:"transactions"`                              //relation has many to Transactions
 	InvalidTransactions []*InvalidTransaction `json:"invalid_transactions"`                      //relation has many to InvalidTransactions
 	Rewards             []*Reward             `json:"rewards"`                                   //relation has many to Rewards
 	Slashes             []*Slash              `json:"slashes"`                                   //relation has many to Slashes
+}
+
+//Return block hash with prefix
+func (t *Block) GetHash() string {
+	return `Mh` + t.Hash
 }

--- a/models/block_validator.go
+++ b/models/block_validator.go
@@ -1,8 +1,9 @@
 package models
 
 type BlockValidator struct {
-	tableName   struct{} `sql:"block_validator"`
-	BlockID     uint64   `json:"block_id"`
-	ValidatorID uint64   `json:"validator_id"`
-	Signed      *bool    `json:"signed"`
+	tableName   struct{}  `sql:"block_validator"`
+	BlockID     uint64    `json:"block_id"`
+	ValidatorID uint64    `json:"validator_id"`
+	Signed      *bool     `json:"signed"`
+	Validator   Validator `json:"validator"`
 }


### PR DESCRIPTION
Заменил Validators на BlockValidator .
Добавил поле Validator в модель BlockValidator. 

В ответе по /blocks и /blocks/{block_id} мне нужно выводить валидаторов (публичный ключ) и подписали/не подписали блок. Поэтому в моделе Block нужен хранить не Validators, а BlockValidators